### PR TITLE
Fix doc dead link

### DIFF
--- a/content/docs/ls-aai/_index.md
+++ b/content/docs/ls-aai/_index.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 -->
 ## Keycloak
 
-Keycloak can be obtained by running the CKAN deployment script eg.: [CKAN deployment script Azure](./../deployment/azure/azure_cli_deployment_guide.md)
+Keycloak can be obtained by running the CKAN deployment script that you can find in the following guide: [CKAN deployment script Azure](./../deployment/azure)
 
 ## Configuring Identity Providers (IdPs)
 

--- a/content/docs/ls-aai/_index.md
+++ b/content/docs/ls-aai/_index.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC-BY-4.0
 -->
 ## Keycloak
 
-Keycloak can be obtained by running the CKAN deployment script that you can find in the following guide: [CKAN deployment script Azure](./../deployment/azure)
+Keycloak can be obtained by running the CKAN deployment script that you can find in the following guide: [Azure CLI Script Deployment Guide](./../deployment/azure)
 
 ## Configuring Identity Providers (IdPs)
 


### PR DESCRIPTION
The `azure_cli_deployment_guide.md` is not existing anymore => 404

I made it a redirect to the `_index.md` instead. 
You might want to redirect to  the script directly maybe ? 
[deploy_to_azure.azcli](https://github.com/GenomicDataInfrastructure/gdi-userportal-deployment/blob/main/deployment_examples/azure/deploy_to_azure.azcli
)