### PR TITLE
docs(harvester): clarify manual and automatic triggering processes

### DIFF
--- a/content/docs/ckan/harvester/harvesting-dcat-ap/_index.md
+++ b/content/docs/ckan/harvester/harvesting-dcat-ap/_index.md
@@ -32,7 +32,7 @@ In the image below you can see example configuration for the last example file. 
 `fairdatapoint_dcat_ap` as `profile` was needed to make sure parsing works with [gdi_useportal schema](https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal/blob/main/ckanext/gdi_userportal/scheming/schemas/gdi_userportal.json) which 
 is different from CKAN default one.
 
-After a harvester job is configured it can be triggered by clicking `Reharvest` in the job's Admin section.
+After a harvester job is configured, it can be triggered manually by clicking Reharvest in the job's Admin section. If you select the manual time interval, you need to do this each time you want to run the job. However, if you set the Update frequency to e.g. daily, a background process will automatically trigger the harvester at the end of each day.
 To test harvesting in Docker Desktop go to the container then click Terminal. Enter the command `ckan --config=/srv/app/ckan.ini harvester run-test <id of harvester>`, the <id of harvester> is the part of the URL of the harvest source.
 
 If successful you'll see datasets uploaded in CKAN.

--- a/content/docs/ckan/harvester/harvesting-fair-data-points/_index.md
+++ b/content/docs/ckan/harvester/harvesting-fair-data-points/_index.md
@@ -38,14 +38,15 @@ The harvester id is the last part of the URL of the harvest source.
 
 ## Overview
 
-The GDI package, available from the GDI GitHub repository, includes a CRON job functionality designed to automate the harvesting of FAIR datapoints. This automation ensures continuous and efficient data collection without manual intervention. The harvesting process is initiated through the CKAN portal, which activates two key background processes responsible for the operation: `ckan_gather_consumer` and `ckan_fetch_consumer`.
+The GDI package, available from the GDI GitHub repository, includes a CRON job functionality designed to automate the harvesting of FAIR datapoints. This automation ensures continuous and efficient data collection without manual intervention. The harvesting process is initiated three background processes responsible for the operation: `run`, `gather_consumer` and `ckan_fetch_consumer`.
 
 ## Background Processes
 
-The harvesting operation relies on two main background processes:
+The harvesting operation relies on three main background processes:
 
-- **`ckan_gather_consumer`**: Manages the gathering of data sources to be harvested.
-- **`ckan_fetch_consumer`**: Responsible for fetching the data from the sources identified by the gather process.
+- **`gather_consumer`**: Manages the gathering of data sources to be harvested.
+- **`fetch_consumer`**: Responsible for fetching the data from the sources identified by the gather process.
+- **`run`**: Responsible for triggering the harvester at the end of each specified time interval (e.g., daily, weekly).
 
 These processes are crucial for the automated harvesting workflow, ensuring that data is continuously and efficiently collected and made available through the CKAN portal.
 


### PR DESCRIPTION
- Refine explanation of the `run` function's role in triggering the harvester at specified intervals (e.g., daily, weekly).
- Improve clarity on configuring harvester jobs and how they can be triggered manually via `Reharvest` or automatically based on the set update frequency.